### PR TITLE
fix(eslint-plugin): update pluginName for rules

### DIFF
--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -11,7 +11,7 @@ const pkg = JSON.parse(
   readFileSync(resolve(__dirname, '../package.json'), 'utf8')
 );
 
-const pluginName = pkg.name.replace('eslint-plugin-', '');
+const pluginName = pkg.name.replace('/eslint-plugin', '');
 
 const basicRules = {
   ...basic,


### PR DESCRIPTION
Fix for:
```
1:1  error  Definition for rule '@brainly-gene/eslint-plugin/use-listener' was not found  @brainly-gene/eslint-plugin/use-listener
```