### PR TITLE
ci: publish package for real (without --dry-run)

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -45,7 +45,8 @@ jobs:
 
       - run: npm whoami
 
-      - run: |
+      - name: Publish to NPM
+        run: |
           cd dist/packages/${{ matrix.packages_to_publish }}
           npm version ${{ github.event.release.tag_name }} --no-git-tag-version
-          npm publish --access public --dry-run
+          npm publish --access public


### PR DESCRIPTION
Use one of those tags for each PR (we can add such tags automatically in future & add PR checker to ensure label exist)

![image](https://github.com/user-attachments/assets/e1a10b0c-3c96-4afd-82a9-21daaa28cb92)

Once we're ready for major release - add new tag `type:breaking`

More info here: https://github.com/brainly/gene/blob/05c0548970e071c60b9eb0009b3fc25e740aee7f/.github/release-drafter.yml#L26-L40

Every merge of PR to base branch will update Draft release. To publish new version - just publish release
