### PR TITLE
fix(generators): Remove apollo by default

### DIFF
--- a/packages/create/bin/create-gene-workspace.js
+++ b/packages/create/bin/create-gene-workspace.js
@@ -102,7 +102,6 @@ async function runCommands() {
       'css-loader@3.6.0',
       'sass@1.55.0',
       'sass-loader@9.0.2',
-      '@apollo/client@3.6.9',
       'classnames@2.5.1',
     ]);
 

--- a/packages/gene-tools/src/generators/e2e-providers-generator/files/lib/ioc/serviceClientsContainer.ts__tmpl__
+++ b/packages/gene-tools/src/generators/e2e-providers-generator/files/lib/ioc/serviceClientsContainer.ts__tmpl__
@@ -1,31 +1,30 @@
-import { Container } from 'inversify';
-import { factory, Factory } from '@brainly-gene/core';
-import { ServiceTypes } from '@brainly-gene/core';
-import { QueryClient } from '@tanstack/react-query';
-import { ApolloClient, InMemoryCache, NormalizedCacheObject } from '@apollo/client';
+import { Container } from "inversify";
+import { factory, Factory } from "@brainly-gene/core";
+import { ServiceTypes } from "@brainly-gene/core";
+import { QueryClient } from "@tanstack/react-query";
+// import { ApolloClient, InMemoryCache, NormalizedCacheObject } from '@apollo/client';
 
 export function useServiceClientsContainer() {
-  const apolloClient = new ApolloClient({
-    uri: 'https://mockurl.com',
-    cache: new InMemoryCache(),
-    ssrMode: true,
-  });
+  // const apolloClient = new ApolloClient({
+  //   uri: 'https://mockurl.com',
+  //   cache: new InMemoryCache(),
+  //   ssrMode: true,
+  // });
   const queryClient = new QueryClient();
 
   const clients = {
     [ServiceTypes.reactQuery]: () => {
       return queryClient;
     },
-    [ServiceTypes.apollo]: () => {
-      return apolloClient;
-    },
+    // [ServiceTypes.apollo]: () => {
+    //   return apolloClient;
+    // },
   };
 
   const container = new Container();
   container
-    .bind<Factory<QueryClient | ApolloClient<NormalizedCacheObject>>>(
-      'serviceFactory'
-    )
+    // .bind<Factory<QueryClient | ApolloClient<NormalizedCacheObject>>>(
+    .bind<Factory<QueryClient>>("serviceFactory")
     .toFunction(factory(clients));
 
   return container;


### PR DESCRIPTION
Apollo should not be installed by default.
Removed dep that is installed with `create-gene-workspace`
Commented apollo usage in e2e testing providers.