### PR TITLE
feat: update storybook generator to do not have `stories` property

### DIFF
--- a/packages/gene-tools/src/generators/storybook-init/files/main.js__tmpl__
+++ b/packages/gene-tools/src/generators/storybook-init/files/main.js__tmpl__
@@ -2,7 +2,6 @@ const { join } = require('path');
 const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
 
 module.exports = {
-  stories: [],
   core: {
     builder: 'webpack5',
   },


### PR DESCRIPTION
this property is now removed by NX in their migrator. See https://github.com/nrwl/nx/blob/17.3.2/packages/storybook/src/migrations/update-15-7-0/add-addon-essentials-to-all.ts#L295