### PR TITLE
fix(generator): enable esModuleInterop in TypeScript compiler options

### DIFF
--- a/packages/gene-tools/src/generators/components-library-generator/index.ts
+++ b/packages/gene-tools/src/generators/components-library-generator/index.ts
@@ -73,6 +73,7 @@ export default async function (
       compilerOptions: {
         ...currentTsconfig.compilerOptions,
         isolatedModules: true,
+        esModuleInterop: true
       },
     };
   });


### PR DESCRIPTION
enable `esModuleInterop` in TypeScript compiler options in components library generator