### PR TITLE
fix(component-generator): update import path for StorybookMediator

### DIFF
--- a/packages/gene-tools/src/generators/component-generator/templates/__filename__.stories.tsx__tmpl__
+++ b/packages/gene-tools/src/generators/component-generator/templates/__filename__.stories.tsx__tmpl__
@@ -3,7 +3,7 @@
 <% } %>
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import {StorybookMediator} from '@brainly-gene/core';
+import {StorybookMediator} from '@brainly-gene/tools';
 <% if (storybookKnobs.length > 0) { %>import {<%= storybookKnobs.join(', ') %>} from '@storybook/addon-knobs';<% } %>
 import <%= classify(name) %> from './<%= classify(name) %>';
 <% if (events) { %>import {<%= eventsTypeName(name) %>} from './<%= eventsTypeName(name) %>';<% } %>


### PR DESCRIPTION
This pull request includes a small change to the `packages/gene-tools/src/generators/component-generator/templates/__filename__.stories.tsx__tmpl__` file. The change updates the import path for `StorybookMediator` to use the `@brainly-gene/tools` package instead of `@brainly-gene/core`.

* [`packages/gene-tools/src/generators/component-generator/templates/__filename__.stories.tsx__tmpl__`](diffhunk://#diff-9cea34e6b712a4a86d94c68f86e15d227a32a423e3dbd3e53f19fa1559d6f431L6-R6): Updated the import path for `StorybookMediator` to `@brainly-gene/tools`.