### PR TITLE
feat(nextjs-app-generator): add TurboPack fallback for non-browser modules

### DIFF
--- a/packages/gene-tools/src/generators/nextjs-app-generator/files/app/next.config.js__tmpl__
+++ b/packages/gene-tools/src/generators/nextjs-app-generator/files/app/next.config.js__tmpl__
@@ -67,6 +67,15 @@ const getConfig = () => {
          */
         largePageDataBytes: 400 * 100000,
         esmExternals: false,
+        turbo: {
+          resolveAlias: {
+            net: './turbopack-non-browser-modules-fallback.js',
+            dns: './turbopack-non-browser-modules-fallback.js',
+            fs: './turbopack-non-browser-modules-fallback.js',
+            path: './turbopack-non-browser-modules-fallback.js',
+            canvas: './turbopack-non-browser-modules-fallback.js',
+          },
+        },
       },
       serverRuntimeConfig: {
         domains,

--- a/packages/gene-tools/src/generators/nextjs-app-generator/files/app/turbopack-non-browser-modules-fallback.js__tmpl__
+++ b/packages/gene-tools/src/generators/nextjs-app-generator/files/app/turbopack-non-browser-modules-fallback.js__tmpl__
@@ -1,0 +1,5 @@
+// Dev only TurboPack fallback for non-browser modules
+// to be used in next.config.js, experimental.turbo.resolveAlias
+// Similar as we have it for webpack here https://github.com/brainly/frontend-monorepo/blob/aea853328a2a7eb0a72530e8f421f6fd6e24fc5e/apps/social-qa/us/withNodeModulesCSS.js#L62-L65
+// More details here: https://github.com/vercel/next.js/discussions/67196#discussioncomment-12380628
+export {};


### PR DESCRIPTION
add resolveAlias configuration under experimental.turbo and auto-generate turbopack fallback