### PR TITLE
fix(gene-next): Update transChoiceHelper to support British English

### DIFF
--- a/packages/gene-next/src/translations/utils/transChoiceHelper.ts
+++ b/packages/gene-next/src/translations/utils/transChoiceHelper.ts
@@ -39,6 +39,8 @@ export function transChoiceHelper({
       case 'en':
       case 'en-US':
       case 'en_US':
+      case 'en-GB':
+      case 'en_GB':
       case 'es-ES':
       case 'es_ES':
       case 'fr':


### PR DESCRIPTION
to make plural form work properly (similar to `en-US`) when `en-GB` locale is detected

<img width="374" alt="Screenshot 2025-05-13 at 14 55 39" src="https://github.com/user-attachments/assets/1070f607-3fc1-4308-8694-6fa0eea3b642" />
